### PR TITLE
feat: add mac battery item

### DIFF
--- a/functions/_tide_item_mac_battery.fish
+++ b/functions/_tide_item_mac_battery.fish
@@ -1,0 +1,30 @@
+function _tide_item_mac_battery
+    set -l info (pmset -g batt | awk 'NR==2 {gsub(/;/,""); print $3 " " $4}')
+    set -l percent (string match -rg '(\d+)%\s*\w+' $info)
+    set -l state (string match -rg '\d+%\s*(\w+)' $info)
+    set -l icons $tide_mac_battery_icons
+    set -l colors $tide_mac_battery_colors
+
+    # icons = [0%, 10%, 20%, 30%, 40%, 50%, 60%, 70%, 80%, 90%, 100%, charging]
+    # colors = [low, normal, charging]
+
+    if test $state != discharging # plugged in, either charging or charged
+        set -f icon $icons[12]
+    else
+        set -l icon_type (math round $percent / 10)
+        set -l icon_idx (math $icon_type + 1)
+
+        set -f icon $icons[$icon_idx]
+    end
+
+    if test $state != discharging
+        set_color $colors[3]
+    else if test $percent -le 20
+        set_color $colors[1]
+    else
+        set_color $colors[2]
+    end
+
+    printf ' %s %s%%' $icon $percent
+    set_color normal
+end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

Add a new prompt item (disabled by default, since it works only on macOS) to display battery percentage.
Requires two variables to be set `$tide_mac_battery_icons` and `$tide_mac_battery_colors`.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
Currently have it set on my right prompt and it works as I expect.

<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

Not really sure there are tests for this for me to update, but if you point me to them I can do it.

- [x] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
